### PR TITLE
  lab07 : fix interaction script

### DIFF
--- a/labs/lab07/lab07/interaction/testnet.snippets.sh
+++ b/labs/lab07/lab07/interaction/testnet.snippets.sh
@@ -45,7 +45,7 @@ localMint() {
         --proxy=${PROXY} --chain=${CHAIN_ID} \
         --value=0 \
         --function="ESDTLocalMint" \
-        --arguments name} ${token_identifier} ${token_decimals} \
+        --arguments ${token_identifier} ${token_decimals} \
         --send || return
 }
 


### PR DESCRIPTION
This PR fixes the interaction script for the lab07 activity. 

The command 

```console
source interaction/testnet.snippets.sh 
```
was failing due to an extra argument and an extra bracket }

Signed-off-by: Radu Nichita <radunichita99@gmail.com>